### PR TITLE
Do not use Object.entries because it doesn't work in Node 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,8 +71,8 @@ function generateRawTags(items = []) {
 }
 
 function wrapItems(item) {
-  return Object.entries(item)
-    .map(([key, val]) => `${key}="${val}"`)
+  return Object.keys(item)
+    .map(key => `${key}="${item[key]}"`)
     .join(' ')
 }
 


### PR DESCRIPTION
P. S. Would be cool to setup Travis CI to prevent that kind of issues.