### PR TITLE
Feat: Expose html attrs for webpack output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
 language: node_js
-cache:
-  directories:
-    - node_modules
+
 node_js:
-  - 6
-  - 8
   - 9
-after_success:
-  - npm install --no-save semantic-release semantic-release-tamia
-  - >-
-    npx travis-deploy-once "semantic-release --analyze-commits semantic-release-tamia/analyzeCommits --verify-release
-    semantic-release-tamia/verifyRelease --generate-notes semantic-release-tamia/generateNotes"
+  - 8
+  - 6
+
+# Trigger a push build on master branches only + PRs build on every branches
+# Avoid double build on PRs (See https://github.com/travis-ci/travis-ci/issues/1147)
 branches:
-  except:
-    - /^v\d+\.\d+\.\d+$/
+  only:
+    - master
+    
+before_install:
+  # Use npm 5.7.x since it has introduced `npm ci`
+  - if [[ `npm -v` != 5.7* ]]; then npm install -g npm@'>=5.7.1'; fi
+
+after_success:
+  - npm install --no-save semantic-release-tamia
+  - >-
+    npx semantic-release --analyze-commits semantic-release-tamia/analyzeCommits --verify-release semantic-release-tamia/verifyRelease --generate-notes semantic-release-tamia/generateNotes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,16 @@
 language: node_js
-
 node_js:
-  - 9
-  - 8
   - 6
-
-# Trigger a push build on master branches only + PRs build on every branches
-# Avoid double build on PRs (See https://github.com/travis-ci/travis-ci/issues/1147)
+  - 8
+  - 9
 branches:
   only:
     - master
-    
 before_install:
-  # Use npm 5.7.x since it has introduced `npm ci`
-  - if [[ `npm -v` != 5.7* ]]; then npm install -g npm@'>=5.7.1'; fi
-
+  - 'if [[ `npm -v` != 5.7* ]]; then npm install -g npm@''>=5.7.1''; fi'
 after_success:
   - npm install --no-save semantic-release-tamia
   - >-
-    npx semantic-release --analyze-commits semantic-release-tamia/analyzeCommits --verify-release semantic-release-tamia/verifyRelease --generate-notes semantic-release-tamia/generateNotes
+    npx semantic-release --analyze-commits semantic-release-tamia/analyzeCommits --verify-release
+    semantic-release-tamia/verifyRelease --generate-notes semantic-release-tamia/generateNotes
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_install:
   - if [[ `npm -v` != 5.7* ]]; then npm install -g npm@'>=5.7.1'; fi
 
 after_success:
-  - if type != pull_request AND branch = master
   - npm install --no-save semantic-release-tamia
   - >-
     npx semantic-release --analyze-commits semantic-release-tamia/analyzeCommits --verify-release semantic-release-tamia/verifyRelease --generate-notes semantic-release-tamia/generateNotes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,20 @@
 language: node_js
+
 node_js:
   - 6
   - 8
   - 9
+
 branches:
   only:
     - master
+
 before_install:
-  - 'if [[ `npm -v` != 5.7* ]]; then npm install -g npm@''>=5.7.1''; fi'
+  - if [[ `npm -v` != 5.7* ]]; then npm install -g npm@'>=5.7.1'; fi
+
 after_success:
+  - if type != pull_request AND branch = master
   - npm install --no-save semantic-release-tamia
   - >-
-    npx semantic-release --analyze-commits semantic-release-tamia/analyzeCommits --verify-release
-    semantic-release-tamia/verifyRelease --generate-notes semantic-release-tamia/generateNotes
-
+    npx semantic-release --analyze-commits semantic-release-tamia/analyzeCommits --verify-release semantic-release-tamia/verifyRelease --generate-notes semantic-release-tamia/generateNotes
+         

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,22 @@ node_js:
   - 8
   - 9
 
+before_install:
+  - if [[ `npm -v` != 5.7* ]]; then npm install -g npm@'>=5.7.1'; fi
+
 branches:
   only:
     - master
 
-before_install:
-  - if [[ `npm -v` != 5.7* ]]; then npm install -g npm@'>=5.7.1'; fi
+stages:
+  - test
+  - name: release
+    if: type != pull_request AND branch = master
 
-after_success:
-  - npm install --no-save semantic-release-tamia
-  - >-
-    npx semantic-release --analyze-commits semantic-release-tamia/analyzeCommits --verify-release semantic-release-tamia/verifyRelease --generate-notes semantic-release-tamia/generateNotes
-         
+jobs:
+  include:
+    - stage: release
+      script:
+        - npm install --no-save semantic-release-tamia
+        - >-
+          npx semantic-release --analyze-commits semantic-release-tamia/analyzeCommits --verify-release semantic-release-tamia/verifyRelease --generate-notes semantic-release-tamia/generateNotes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @vxna/mini-html-webpack-template
 
+[![Build Status](https://travis-ci.org/vxna/@vxna/mini-html-webpack-template.svg)](https://travis-ci.org/vxna/@vxna/mini-html-webpack-template)
+
 Template for [mini-html-webpack-plugin](https://github.com/bebraw/mini-html-webpack-plugin) that extends default features with useful subset of options
 
 ## Warning

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @vxna/mini-html-webpack-template
 
-[![Build Status](https://travis-ci.org/vxna/@vxna/mini-html-webpack-template.svg)](https://travis-ci.org/vxna/@vxna/mini-html-webpack-template)
+[![Build Status](https://travis-ci.com/vxna/mini-html-webpack-template.svg)](https://travis-ci.com/vxna/mini-html-webpack-template)
 
 Template for [mini-html-webpack-plugin](https://github.com/bebraw/mini-html-webpack-plugin) that extends default features with useful subset of options
 

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ module.exports = {
 
 ## Common options
 
-| Name                 |    Type     |    Default     | Description                        |
-| -------------------- | :---------: | :------------: | :--------------------------------- |
-| **`lang`**           | `{String}`  |  `undefined`   | Set document language              |
+| Name                 | Type        | Default        | Description                        |
+| -------------------- | ----------- | -------------- | ---------------------------------- |
+| **`lang`**           | `{String}`  | `undefined`    | Set document language              |
 | **`title`**          | `{String}`  | `'sample-app'` | Set document title                 |
-| **`favicon`**        | `{String}`  |  `undefined`   | Set document favicon               |
-| **`container`**      | `{String}`  |  `undefined`   | Set application mount point        |
-| **`trimWhitespace`** | `{Boolean}` |  `undefined`   | Safe document whitespace reduction |
+| **`favicon`**        | `{String}`  | `undefined`    | Set document favicon               |
+| **`container`**      | `{String}`  | `undefined`    | Set application mount point        |
+| **`trimWhitespace`** | `{Boolean}` | `undefined`    | Safe document whitespace reduction |
 
 ## Extended usage
 
@@ -62,12 +62,10 @@ module.exports = {
           raw: '<div id="root"></div>'
         },
         attrs: {
-          js: [
-            {
-              async: '',
-              type: 'text/javascript'
-            }
-          ]
+          js: {
+            async: '',
+            type: 'text/javascript'
+          }
         }
       },
       template: require('@vxna/mini-html-webpack-template')
@@ -78,16 +76,16 @@ module.exports = {
 
 ## Extended options
 
-| Name               |       Type        |   Default   | Description                               |
-| ------------------ | :---------------: | :---------: | :---------------------------------------- |
-| **`head.meta`**    |     `{Array}`     | `undefined` | Array of objects with key + value pairs   |
-| **`head.links`**   |     `{Array}`     | `undefined` | Array of objects with key + value pairs   |
-| **`head.scripts`** |     `{Array}`     | `undefined` | Array of objects with key + value pairs   |
-| **`head.raw`**     | `{Array\|String}` | `undefined` | Raw document markup                       |
-| **`body.scripts`** |     `{Array}`     | `undefined` | Array of objects with key + value pairs   |
-| **`body.raw`**     | `{Array\|String}` | `undefined` | Raw document markup                       |
-| **`attrs.js`**     |     `{Array}`     | `undefined` | Applies html attributes to webpack output |
-| **`attrs.css`**    |     `{Array}`     | `undefined` | Applies html attributes to webpack output |
+| Name               | Type              | Default     | Description                               |
+| ------------------ | ----------------- | ----------- | ----------------------------------------- |
+| **`head.meta`**    | `{Array}`         | `undefined` | Array of objects with key + value pairs   |
+| **`head.links`**   | `{Array}`         | `undefined` | Array of objects with key + value pairs   |
+| **`head.scripts`** | `{Array}`         | `undefined` | Array of objects with key + value pairs   |
+| **`head.raw`**     | `{Array\|String}` | `undefined` | Generates raw document markup             |
+| **`body.scripts`** | `{Array}`         | `undefined` | Array of objects with key + value pairs   |
+| **`body.raw`**     | `{Array\|String}` | `undefined` | Generates raw document markup             |
+| **`attrs.js`**     | `{Object}`        | `undefined` | Applies html attributes to webpack output |
+| **`attrs.css`**    | `{Object}`        | `undefined` | Applies html attributes to webpack output |
 
 ## Advanced minification
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ module.exports = {
         },
         body: {
           raw: '<div id="root"></div>'
+        },
+        attrs: {
+          js: [
+            {
+              async: '',
+              type: 'text/javascript'
+            }
+          ]
         }
       },
       template: require('@vxna/mini-html-webpack-template')
@@ -81,14 +89,16 @@ module.exports = {
 
 ## Extended options
 
-|        Name        |       Type        |   Default   | Description                             |
-| :----------------: | :---------------: | :---------: | :-------------------------------------- |
-|  **`head.meta`**   |     `{Array}`     | `undefined` | Array of objects with key + value pairs |
-|  **`head.links`**  |     `{Array}`     | `undefined` | Array of objects with key + value pairs |
-| **`head.scripts`** |     `{Array}`     | `undefined` | Array of objects with key + value pairs |
-|   **`head.raw`**   | `{Array\|String}` | `undefined` | Raw document markup                     |
-| **`body.scripts`** |     `{Array}`     | `undefined` | Array of objects with key + value pairs |
-|   **`body.raw`**   | `{Array\|String}` | `undefined` | Raw document markup                     |
+|        Name        |       Type        |   Default   | Description                               |
+| :----------------: | :---------------: | :---------: | :---------------------------------------- |
+|  **`head.meta`**   |     `{Array}`     | `undefined` | Array of objects with key + value pairs   |
+|  **`head.links`**  |     `{Array}`     | `undefined` | Array of objects with key + value pairs   |
+| **`head.scripts`** |     `{Array}`     | `undefined` | Array of objects with key + value pairs   |
+|   **`head.raw`**   | `{Array\|String}` | `undefined` | Raw document markup                       |
+| **`body.scripts`** |     `{Array}`     | `undefined` | Array of objects with key + value pairs   |
+|   **`body.raw`**   | `{Array\|String}` | `undefined` | Raw document markup                       |
+|   **`attrs.js`**   |     `{Array}`     | `undefined` | Applies html attributes to webpack output |
+|  **`attrs.css`**   |     `{Array}`     | `undefined` | Applies html attributes to webpack output |
 
 ## Advanced minification
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @vxna/mini-html-webpack-template
 
-[![Build Status](https://travis-ci.com/vxna/mini-html-webpack-template.svg)](https://travis-ci.com/vxna/mini-html-webpack-template)
+[![Build Status](https://travis-ci.com/vxna/mini-html-webpack-template.svg)](https://travis-ci.com/vxna/mini-html-webpack-template) [![npm](https://img.shields.io/npm/v/@vxna/mini-html-webpack-template.svg)](https://www.npmjs.com/package/@vxna/mini-html-webpack-template)
 
 Template for [mini-html-webpack-plugin](https://github.com/bebraw/mini-html-webpack-plugin) that extends default features with useful subset of options
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ module.exports = {
 
 ## Common options
 
-|         Name         |    Type     |    Default     | Description                        |
-| :------------------: | :---------: | :------------: | :--------------------------------- |
-|      **`lang`**      | `{String}`  |  `undefined`   | Set document language              |
-|     **`title`**      | `{String}`  | `'sample-app'` | Set document title                 |
-|    **`favicon`**     | `{String}`  |  `undefined`   | Set document favicon               |
-|   **`container`**    | `{String}`  |  `undefined`   | Set application mount point        |
+| Name                 |    Type     |    Default     | Description                        |
+| -------------------- | :---------: | :------------: | :--------------------------------- |
+| **`lang`**           | `{String}`  |  `undefined`   | Set document language              |
+| **`title`**          | `{String}`  | `'sample-app'` | Set document title                 |
+| **`favicon`**        | `{String}`  |  `undefined`   | Set document favicon               |
+| **`container`**      | `{String}`  |  `undefined`   | Set application mount point        |
 | **`trimWhitespace`** | `{Boolean}` |  `undefined`   | Safe document whitespace reduction |
 
 ## Extended usage
@@ -55,17 +55,6 @@ module.exports = {
             {
               name: 'description',
               content: 'mini-html-webpack-template'
-            },
-            {
-              property: 'og:description',
-              content: 'mini-html-webpack-template'
-            }
-          ],
-          links: [
-            {
-              rel: 'icon',
-              type: 'image/x-icon',
-              href: 'https://assets-cdn.github.com/favicon.ico'
             }
           ]
         },
@@ -89,16 +78,16 @@ module.exports = {
 
 ## Extended options
 
-|        Name        |       Type        |   Default   | Description                               |
-| :----------------: | :---------------: | :---------: | :---------------------------------------- |
-|  **`head.meta`**   |     `{Array}`     | `undefined` | Array of objects with key + value pairs   |
-|  **`head.links`**  |     `{Array}`     | `undefined` | Array of objects with key + value pairs   |
+| Name               |       Type        |   Default   | Description                               |
+| ------------------ | :---------------: | :---------: | :---------------------------------------- |
+| **`head.meta`**    |     `{Array}`     | `undefined` | Array of objects with key + value pairs   |
+| **`head.links`**   |     `{Array}`     | `undefined` | Array of objects with key + value pairs   |
 | **`head.scripts`** |     `{Array}`     | `undefined` | Array of objects with key + value pairs   |
-|   **`head.raw`**   | `{Array\|String}` | `undefined` | Raw document markup                       |
+| **`head.raw`**     | `{Array\|String}` | `undefined` | Raw document markup                       |
 | **`body.scripts`** |     `{Array}`     | `undefined` | Array of objects with key + value pairs   |
-|   **`body.raw`**   | `{Array\|String}` | `undefined` | Raw document markup                       |
-|   **`attrs.js`**   |     `{Array}`     | `undefined` | Applies html attributes to webpack output |
-|  **`attrs.css`**   |     `{Array}`     | `undefined` | Applies html attributes to webpack output |
+| **`body.raw`**     | `{Array\|String}` | `undefined` | Raw document markup                       |
+| **`attrs.js`**     |     `{Array}`     | `undefined` | Applies html attributes to webpack output |
+| **`attrs.css`**    |     `{Array}`     | `undefined` | Applies html attributes to webpack output |
 
 ## Advanced minification
 
@@ -129,7 +118,7 @@ module.exports = {
 
 ## Complex security features
 
-[SRI](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) is out of scope of this project and it's recommended to use [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) with tools like [webpack-subresource-integrity](webpack-subresource-integrity) or others.
+[SRI](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) is out of scope of this project and it's recommended to use [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) with it's ecosystem tools.
 
 ## Inspired by
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ module.exports = {
 | **`body.scripts`** |     `{Array}`     | `undefined` | Array of objects with key + value pairs |
 |   **`body.raw`**   | `{Array\|String}` | `undefined` | Raw document markup                     |
 
-## Extended minification
+## Advanced minification
 
 For custom needs [html-minifier](https://github.com/kangax/html-minifier) middleware and all of it's [options](https://github.com/kangax/html-minifier#options-quick-reference) could be used
 
@@ -104,7 +104,7 @@ module.exports = {
   plugins: [
     new MiniHtmlWebpackPlugin({
       context: {
-        title: 'extended-minification'
+        title: 'advanced-minification'
       },
       template: ctx =>
         minify(require('@vxna/mini-html-webpack-template')(ctx), {
@@ -116,6 +116,10 @@ module.exports = {
   ]
 }
 ```
+
+## Complex security features
+
+[SRI](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) is out of scope of this project and it's recommended to use [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) with tools like [webpack-subresource-integrity](webpack-subresource-integrity) or others.
 
 ## Inspired by
 

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -1,25 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`advanced options 1`] = `
+exports[`options: advanced 1`] = `
 "<!DOCTYPE html>
 <html lang=\\"en\\">
   <head>
-    <meta charset=\\"UTF-8\\">
+    <meta charset=\\"utf-8\\">
     <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
     <meta http-equiv=\\"X-UA-Compatible\\" content=\\"ie=edge\\">
     <title>advanced options</title>
     <meta name=\\"description\\" content=\\"mini-html-webpack-template\\">
     <meta property=\\"og:description\\" content=\\"mini-html-webpack-template\\">
     <link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\">
+    <script defer=\\"\\" type=\\"text/javascript\\" src=\\"https://unpkg.com/random\\"></script>
     <style id=\\"head-raw-string\\"></style>
-    <script async=\\"\\" type=\\"text/javascript\\" src=\\"/bundle.js\\"></script>
+    <link rel=\\"stylesheet\\" href=\\"main.css\\">
   </head>
   <body>
     <script id=\\"body-raw-array-1\\"></script>
     <script id=\\"body-raw-array-2\\"></script>
-    <script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
+    <script src=\\"runtime~main.js\\"></script>
+    <script src=\\"main.js\\"></script>
   </body>
 </html>"
 `;
 
-exports[`common options 1`] = `"<!DOCTYPE html><html><head><meta charset=\\"UTF-8\\"><meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\"><meta http-equiv=\\"X-UA-Compatible\\" content=\\"ie=edge\\"><title>common options</title><link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\"></head><body><div id=\\"root\\"></div><script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script></body></html>"`;
+exports[`options: common 1`] = `
+"<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=\\"utf-8\\">
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+    <meta http-equiv=\\"X-UA-Compatible\\" content=\\"ie=edge\\">
+    <title>common options</title>
+    <link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\">
+    <link rel=\\"stylesheet\\" href=\\"main.css\\">
+  </head>
+  <body>
+    <div id=\\"root\\"></div>
+    <script src=\\"runtime~main.js\\"></script>
+    <script src=\\"main.js\\"></script>
+  </body>
+</html>"
+`;
+
+exports[`options: output attrs 1`] = `
+"<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=\\"utf-8\\">
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+    <meta http-equiv=\\"X-UA-Compatible\\" content=\\"ie=edge\\">
+    <title>output attrs</title>
+    <link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\">
+    <link type=\\"text/css\\" rel=\\"stylesheet\\" href=\\"main.css\\">
+  </head>
+  <body>
+    <div id=\\"root\\"></div>
+    <script async=\\"\\" type=\\"text/javascript\\" src=\\"runtime~main.js\\"></script>
+    <script async=\\"\\" type=\\"text/javascript\\" src=\\"main.js\\"></script>
+  </body>
+</html>"
+`;
+
+exports[`options: trim whitespace 1`] = `"<!DOCTYPE html><html><head><meta charset=\\"utf-8\\"><meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\"><meta http-equiv=\\"X-UA-Compatible\\" content=\\"ie=edge\\"><title>trim whitespace</title><link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\"><link rel=\\"stylesheet\\" href=\\"main.css\\"></head><body><div id=\\"root\\"></div><script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script></body></html>"`;

--- a/index.js
+++ b/index.js
@@ -66,15 +66,13 @@ function generateRawTags(tags = []) {
   return tags.map(tag => tag)
 }
 
-function webpackArtifacts(files = [], publicPath = '', attrs = [], type) {
+function webpackArtifacts(files = [], publicPath = '', attrs = {}, type) {
   const tag = file =>
     type === 'script'
-      ? [...attrs, ...[{ src: publicPath + file }]]
-      : [...attrs, ...[{ rel: 'stylesheet', href: publicPath + file }]]
+      ? Object.assign(attrs, { src: publicPath + file })
+      : Object.assign(attrs, { rel: 'stylesheet', href: publicPath + file })
 
-  return files
-    .map(file => generateTags([Object.assign(...tag(file))], type))
-    .join('\n')
+  return files.map(file => generateTags([tag(file)], type)).join('\n')
 }
 
 const emptyLineTrim = new TemplateTag(

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function generateRawTags(tags = []) {
   return tags.map(tag => tag)
 }
 
-function webpackArtifacts(files = [], publicPath = '', attrs = '', type) {
+function webpackArtifacts(files = [], publicPath = '', attrs = [], type) {
   const tag = file =>
     type === 'script'
       ? [].concat(attrs, [{ src: publicPath + file }])

--- a/index.js
+++ b/index.js
@@ -69,15 +69,12 @@ function generateRawTags(tags = []) {
 function webpackArtifacts(files = [], publicPath = '', attrs = [], type) {
   const tag = file =>
     type === 'script'
-      ? [].concat(attrs, [{ src: publicPath + file }])
-      : [].concat(attrs, [{ rel: 'stylesheet', href: publicPath + file }])
+      ? [...attrs, ...[{ src: publicPath + file }]]
+      : [...attrs, ...[{ rel: 'stylesheet', href: publicPath + file }]]
 
-  return (
-    files
-      // eslint-disable-next-line prefer-spread
-      .map(file => generateTags([Object.assign.apply(Object, tag(file))], type))
-      .join('\n')
-  )
+  return files
+    .map(file => generateTags([Object.assign(...tag(file))], type))
+    .join('\n')
 }
 
 const emptyLineTrim = new TemplateTag(

--- a/index.js
+++ b/index.js
@@ -6,11 +6,6 @@ const {
   replaceResultTransformer
 } = require('common-tags')
 
-const {
-  generateCSSReferences,
-  generateJSReferences
-} = require('mini-html-webpack-plugin')
-
 function template(ctx) {
   const {
     publicPath,
@@ -20,60 +15,69 @@ function template(ctx) {
     title,
     favicon,
     container,
-    head = [],
-    body = [],
+    head = {},
+    body = {},
+    attrs = {},
     trimWhitespace
   } = ctx
 
   const doc = html`
   <!DOCTYPE html>
-  <html${lang && ` lang="${lang}"`}>
+  ${lang ? `<html lang="${lang}">` : '<html>'}
     <head>
-      <meta charset="UTF-8">
+      <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <meta http-equiv="X-UA-Compatible" content="ie=edge">
       <title>${title || 'sample-app'}</title>
       ${favicon && `<link rel="icon" type="image/x-icon" href="${favicon}">`}
-      ${generateMetaTags(head.meta)}
-      ${generateLinkTags(head.links)}
+      ${generateTags(head.meta, 'meta')}
+      ${generateTags(head.links, 'link')}
+      ${generateTags(head.style, 'style')}
+      ${generateTags(head.scripts, 'script')}
       ${generateRawTags(head.raw)}
-      ${generateScriptTags(head.scripts)}
-      ${generateCSSReferences(css, publicPath)}
+      ${webpackArtifacts(css, publicPath, attrs.css, 'link')}
     </head>
     <body>
       ${container && `<div id="${container}"></div>`}
       ${generateRawTags(body.raw)}
-      ${generateScriptTags(body.scripts)}
-      ${generateJSReferences(js, publicPath)}
+      ${generateTags(body.scripts, 'script')}
+      ${webpackArtifacts(js, publicPath, attrs.js, 'script')}
     </body>
   </html>`
 
   return trimWhitespace ? oneLineTrim(doc) : emptyLineTrim(doc)
 }
 
-function generateMetaTags(items = []) {
-  return items.map(item => `<meta ${wrapItems(item)}>`)
-}
-
-function generateLinkTags(items = []) {
-  return items.map(item => `<link ${wrapItems(item)}>`)
-}
-
-function generateScriptTags(items = []) {
-  return items.map(item => `<script ${wrapItems(item)}></script>`)
-}
-
-function generateRawTags(items = []) {
-  if (typeof items === 'string' || items instanceof String) {
-    return items
-  }
-  return items.map(item => item)
-}
-
-function wrapItems(item) {
-  return Object.keys(item)
-    .map(key => `${key}="${item[key]}"`)
+function mapAttrs(tag) {
+  return Object.keys(tag)
+    .map(attr => `${attr}="${tag[attr]}"`)
     .join(' ')
+}
+
+function generateTags(tags = [], type) {
+  const closing = type === ('script' || 'style') ? `></${type}>` : '>'
+  return tags.map(tag => `<${type} ${mapAttrs(tag)}${closing}`)
+}
+
+function generateRawTags(tags = []) {
+  if (typeof tags === 'string' || tags instanceof String) {
+    return tags
+  }
+  return tags.map(tag => tag)
+}
+
+function webpackArtifacts(files = [], publicPath = '', attrs = '', type) {
+  const tag = file =>
+    type === 'script'
+      ? [].concat(attrs, [{ src: publicPath + file }])
+      : [].concat(attrs, [{ rel: 'stylesheet', href: publicPath + file }])
+
+  return (
+    files
+      // eslint-disable-next-line prefer-spread
+      .map(file => generateTags([Object.assign.apply(Object, tag(file))], type))
+      .join('\n')
+  )
 }
 
 const emptyLineTrim = new TemplateTag(

--- a/package-lock.json
+++ b/package-lock.json
@@ -2147,6 +2147,50 @@
         "randomfill": "^1.0.3"
       }
     },
+    "css-loader": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-2.1.1.tgz",
+      "integrity": "sha512-OcKJU/lt232vl1P9EEDamhoO9iKY3tIjY5GU+XDLblAykTdgs6Ux9P1hTHve8nFKy5KPpOXOsVI/hIwi3841+w==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.2.0",
+        "icss-utils": "^4.1.0",
+        "loader-utils": "^1.2.3",
+        "normalize-path": "^3.0.0",
+        "postcss": "^7.0.14",
+        "postcss-modules-extract-imports": "^2.0.0",
+        "postcss-modules-local-by-default": "^2.0.6",
+        "postcss-modules-scope": "^2.1.0",
+        "postcss-modules-values": "^2.0.0",
+        "postcss-value-parser": "^3.3.0",
+        "schema-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true
+    },
     "cssom": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
@@ -4189,6 +4233,21 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
+    },
+    "icss-utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.0.tgz",
+      "integrity": "sha512-3DEun4VOeMvSczifM3F2cKQrDQ5Pj6WKhkOq6HD4QTnDUAq8MQRxy5TX6Sy1iY6WPBe4gQ3p5vTECjbIkglkkQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.14"
+      }
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -4254,6 +4313,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+      "dev": true
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
     "indexof": {
@@ -5975,6 +6040,30 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
+    },
+    "mini-css-extract-plugin": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz",
+      "integrity": "sha512-IuaLjruM0vMKhUUT51fQdQzBYTX49dLj8w68ALEAe2A4iYNpIC4eMac67mt3NzycvjOlf07/kYxJDc0RTl1Wqw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^1.0.0",
+        "webpack-sources": "^1.1.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
     },
     "mini-html-webpack-plugin": {
       "version": "0.2.3",
@@ -9913,6 +10002,85 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "postcss": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+      "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.5"
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.6.tgz",
+      "integrity": "sha512-oLUV5YNkeIBa0yQl7EYnxMgy4N6noxmiwZStaEJUSe2xPMcdNc8WmBQuQCx18H5psYbVxz8zoHk0RAAYZXP9gA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0",
+        "postcss-value-parser": "^3.3.1"
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.0.tgz",
+      "integrity": "sha512-91Rjps0JnmtUB0cujlc8KIKCsJXWjzuxGeT/+Q2i2HXKZ7nBUeF9YQTZZTNvHVoNYj1AthsjnGLtqDUE0Op79A==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
+      }
+    },
+    "postcss-modules-values": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz",
+      "integrity": "sha512-Ki7JZa7ff1N3EIMlPnGTZfUMe69FFwiQPnVSXC9mnn3jozCRBYIxiZd44yJOV2AmabOo4qFf8s0dC/+lweG7+w==",
+      "dev": true,
+      "requires": {
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^7.0.6"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+      "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -11502,6 +11670,12 @@
           }
         }
       }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
     },
     "unique-filename": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -21,15 +21,14 @@
   },
   "scripts": {
     "pretest": "npm run lint",
-    "test": "true && npm run test:jest",
-    "posttest": "npm run format",
-    "lint": "eslint . --cache --fix",
-    "format": "prettier --write **/*.{js,md}",
-    "precommit": "lint-staged",
+    "test": "npm run test:jest",
     "test:jest": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "semantic-release": "semantic-release"
+    "posttest": "npm run format",
+    "lint": "eslint . --cache --fix",
+    "format": "prettier --write **/*.{js,md}",
+    "precommit": "lint-staged"
   },
   "dependencies": {
     "common-tags": "^1.8.0"
@@ -59,12 +58,13 @@
     "semi": false
   },
   "lint-staged": {
-    "*.{js,md}": [
+    "*.js": [
+      "eslint --fix",
       "prettier --write",
       "git add"
     ],
-    "*.js": [
-      "eslint --fix",
+    "*.md": [
+      "prettier --write",
       "git add"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -36,15 +36,17 @@
   },
   "devDependencies": {
     "@webpack-contrib/test-utils": "^0.1.3",
+    "css-loader": "^2.1.1",
     "eslint": "^5.15.3",
     "eslint-config-tamia": "^6.0.2",
     "husky": "^1.3.1",
     "jest": "^24.5.0",
     "lint-staged": "^8.1.5",
+    "mini-css-extract-plugin": "^0.5.0",
     "mini-html-webpack-plugin": "^0.2.3",
     "prettier": "^1.16.4",
-    "webpack": "^4.29.6",
-    "semantic-release": "^15.13.3"
+    "semantic-release": "^15.13.3",
+    "webpack": "^4.29.6"
   },
   "publishConfig": {
     "access": "public"

--- a/test.js
+++ b/test.js
@@ -1,35 +1,43 @@
+const path = require('path')
 const compiler = require('@webpack-contrib/test-utils')
 const MiniHtmlWebpackPlugin = require('mini-html-webpack-plugin')
+const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
 const getConfig = (options, config = {}) =>
   Object.assign(
     {
-      entry: ['./index.js'],
+      entry: path.resolve(__dirname, 'test', 'fixtures'),
+      rules: [
+        {
+          test: /\.css$/,
+          use: [MiniCssExtractPlugin.loader, 'css-loader']
+        }
+      ],
       plugins: [
         new MiniHtmlWebpackPlugin({
           context: options,
           template: require('./')
-        })
+        }),
+        new MiniCssExtractPlugin()
       ]
     },
     config
   )
 
-test('common options', () => {
+test('options: common', () => {
   return compiler(
     {},
     getConfig({
       title: 'common options',
       favicon: '/favicon.ico',
-      container: 'root',
-      trimWhitespace: true
+      container: 'root'
     })
   ).then(result => {
     expect(result.compilation.assets['index.html']._value).toMatchSnapshot()
   })
 })
 
-test('advanced options', () => {
+test('options: advanced', () => {
   return compiler(
     {},
     getConfig({
@@ -55,9 +63,9 @@ test('advanced options', () => {
         ],
         scripts: [
           {
-            async: '',
+            defer: '',
             type: 'text/javascript',
-            src: '/bundle.js'
+            src: 'https://unpkg.com/random'
           }
         ],
         raw: '<style id="head-raw-string"></style>'
@@ -68,6 +76,37 @@ test('advanced options', () => {
           '<script id="body-raw-array-2"></script>'
         ]
       }
+    })
+  ).then(result => {
+    expect(result.compilation.assets['index.html']._value).toMatchSnapshot()
+  })
+})
+
+test('options: output attrs', () => {
+  return compiler(
+    {},
+    getConfig({
+      title: 'output attrs',
+      favicon: '/favicon.ico',
+      container: 'root',
+      attrs: {
+        js: [{ async: '', type: 'text/javascript' }],
+        css: [{ type: 'text/css' }]
+      }
+    })
+  ).then(result => {
+    expect(result.compilation.assets['index.html']._value).toMatchSnapshot()
+  })
+})
+
+test('options: trim whitespace', () => {
+  return compiler(
+    {},
+    getConfig({
+      title: 'trim whitespace',
+      favicon: '/favicon.ico',
+      container: 'root',
+      trimWhitespace: true
     })
   ).then(result => {
     expect(result.compilation.assets['index.html']._value).toMatchSnapshot()

--- a/test.js
+++ b/test.js
@@ -90,8 +90,8 @@ test('options: output attrs', () => {
       favicon: '/favicon.ico',
       container: 'root',
       attrs: {
-        js: [{ async: '', type: 'text/javascript' }],
-        css: [{ type: 'text/css' }]
+        js: { async: '', type: 'text/javascript' },
+        css: { type: 'text/css' }
       }
     })
   ).then(result => {

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,0 +1,1 @@
+import './styles.css'

--- a/test/fixtures/styles.css
+++ b/test/fixtures/styles.css
@@ -1,0 +1,3 @@
+body {
+  margin: 0;
+}


### PR DESCRIPTION
TIL styleguidist/mini-html-webpack-plugin#6 is not going to be implemented and I am myself in need of this feature so I've decided to implement this at template level as I think it's a more suitable place for it.

There is no breaking changes I am aware of but I am going to release this as 1.0.0 anyways.

/cc @sapegin thoughts?